### PR TITLE
Add support for --pattern to lifecycle-config.

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -293,9 +293,12 @@
 |<<prompt.radius,prompt.radius>>|Rounding radius (in pixels) for the edges of prompts.
 |<<qt.args,qt.args>>|Additional arguments to pass to Qt, without leading `--`.
 |<<qt.chromium.experimental_web_platform_features,qt.chromium.experimental_web_platform_features>>|Enables Web Platform features that are in development.
+|<<qt.chromium.lifecycle_state_discard_delay,qt.chromium.lifecycle_state_discard_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
+|<<qt.chromium.lifecycle_state_freeze_delay,qt.chromium.lifecycle_state_freeze_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
 |<<qt.chromium.low_end_device_mode,qt.chromium.low_end_device_mode>>|When to use Chromium's low-end device mode.
 |<<qt.chromium.process_model,qt.chromium.process_model>>|Which Chromium process model to use.
 |<<qt.chromium.sandboxing,qt.chromium.sandboxing>>|What sandboxing mechanisms in Chromium to use.
+|<<qt.chromium.use_recommended_page_lifecycle_state,qt.chromium.use_recommended_page_lifecycle_state>>|Use recommended page lifecycle state.
 |<<qt.environ,qt.environ>>|Additional environment variables to set.
 |<<qt.force_platform,qt.force_platform>>|Force a Qt platform to use.
 |<<qt.force_platformtheme,qt.force_platformtheme>>|Force a Qt platformtheme to use.
@@ -3843,6 +3846,26 @@ Valid values:
 
 Default: +pass:[auto]+
 
+[[qt.chromium.lifecycle_state_discard_delay]]
+=== qt.chromium.lifecycle_state_discard_delay
+The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Int>>
+
+Default: +pass:[0]+
+
+[[qt.chromium.lifecycle_state_freeze_delay]]
+=== qt.chromium.lifecycle_state_freeze_delay
+The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Int>>
+
+Default: +pass:[0]+
+
 [[qt.chromium.low_end_device_mode]]
 === qt.chromium.low_end_device_mode
 When to use Chromium's low-end device mode.
@@ -3909,6 +3932,19 @@ Valid values:
  * +disable-all+: Disable all sandboxing (**not recommended!**).
 
 Default: +pass:[enable-all]+
+
+[[qt.chromium.use_recommended_page_lifecycle_state]]
+=== qt.chromium.use_recommended_page_lifecycle_state
+Use recommended page lifecycle state.
+This puts webpages into one of three lifecycle states: active, frozen, or discarded. Using the recommended lifecycle state lets the browser use less resources by freezing or discarding web views when it's safe to do so.
+This results in significant battery life savings.
+Ongoing page activity is taken into account when determining the recommended lifecycle state, as to not disrupt your browsing.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Bool>>
+
+Default: +pass:[false]+
 
 [[qt.environ]]
 === qt.environ

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -177,6 +177,9 @@
 |<<content.javascript.log_message.levels,content.javascript.log_message.levels>>|Javascript message sources/levels to show in the qutebrowser UI.
 |<<content.javascript.modal_dialog,content.javascript.modal_dialog>>|Use the standard JavaScript modal dialog for `alert()` and `confirm()`.
 |<<content.javascript.prompt,content.javascript.prompt>>|Show javascript prompts.
+|<<content.lifecycle.enabled,content.lifecycle.enabled>>|Enable use of recommended page lifecycle state.
+|<<content.lifecycle.discard_ms,content.lifecycle.discard_ms>>|The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
+|<<content.lifecycle.freeze_ms,content.lifecycle.freeze_ms>>|The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
 |<<content.local_content_can_access_file_urls,content.local_content_can_access_file_urls>>|Allow locally loaded documents to access other local URLs.
 |<<content.local_content_can_access_remote_urls,content.local_content_can_access_remote_urls>>|Allow locally loaded documents to access remote URLs.
 |<<content.local_storage,content.local_storage>>|Enable support for HTML 5 local storage and Web SQL.
@@ -293,12 +296,9 @@
 |<<prompt.radius,prompt.radius>>|Rounding radius (in pixels) for the edges of prompts.
 |<<qt.args,qt.args>>|Additional arguments to pass to Qt, without leading `--`.
 |<<qt.chromium.experimental_web_platform_features,qt.chromium.experimental_web_platform_features>>|Enables Web Platform features that are in development.
-|<<qt.chromium.lifecycle_state_discard_delay,qt.chromium.lifecycle_state_discard_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
-|<<qt.chromium.lifecycle_state_freeze_delay,qt.chromium.lifecycle_state_freeze_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
 |<<qt.chromium.low_end_device_mode,qt.chromium.low_end_device_mode>>|When to use Chromium's low-end device mode.
 |<<qt.chromium.process_model,qt.chromium.process_model>>|Which Chromium process model to use.
 |<<qt.chromium.sandboxing,qt.chromium.sandboxing>>|What sandboxing mechanisms in Chromium to use.
-|<<qt.chromium.use_recommended_page_lifecycle_state,qt.chromium.use_recommended_page_lifecycle_state>>|Use recommended page lifecycle state.
 |<<qt.environ,qt.environ>>|Additional environment variables to set.
 |<<qt.force_platform,qt.force_platform>>|Force a Qt platform to use.
 |<<qt.force_platformtheme,qt.force_platformtheme>>|Force a Qt platformtheme to use.
@@ -2459,6 +2459,45 @@ Type: <<types,Bool>>
 
 Default: +pass:[true]+
 
+[[content.lifecycle.discard_ms]]
+=== content.lifecycle.discard_ms
+The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
+Set to -1 to disable
+
+This setting is only available with the QtWebEngine backend.
+
+This setting supports link:configuring{outfilesuffix}#patterns[URL patterns].
+
+Type: <<types,Int>>
+
+Default: +pass:[-1]+
+
+[[content.lifecycle.freeze_ms]]
+=== content.lifecycle.freeze_ms
+The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
+To disable set content.lifecycle.enabled to false.
+
+This setting is only available with the QtWebEngine backend.
+
+This setting supports link:configuring{outfilesuffix}#patterns[URL patterns].
+
+Type: <<types,Int>>
+
+Default: +pass:[600000]+
+
+[[content.lifecycle.enabled]]
+=== content.lifecycle.enabled
+Enable use of recommended page lifecycle state.
+This puts webpages into one of three lifecycle states: active, frozen, or discarded. Using the recommended lifecycle state lets the browser use less resources by freezing or discarding web views when it's safe to do so.
+This results in significant battery life savings.
+Ongoing page activity is taken into account when determining the recommended lifecycle state, as to not disrupt your browsing.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Bool>>
+
+Default: +pass:[true]+
+
 [[content.local_content_can_access_file_urls]]
 === content.local_content_can_access_file_urls
 Allow locally loaded documents to access other local URLs.
@@ -3846,26 +3885,6 @@ Valid values:
 
 Default: +pass:[auto]+
 
-[[qt.chromium.lifecycle_state_discard_delay]]
-=== qt.chromium.lifecycle_state_discard_delay
-The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
-
-This setting is only available with the QtWebEngine backend.
-
-Type: <<types,Int>>
-
-Default: +pass:[0]+
-
-[[qt.chromium.lifecycle_state_freeze_delay]]
-=== qt.chromium.lifecycle_state_freeze_delay
-The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
-
-This setting is only available with the QtWebEngine backend.
-
-Type: <<types,Int>>
-
-Default: +pass:[0]+
-
 [[qt.chromium.low_end_device_mode]]
 === qt.chromium.low_end_device_mode
 When to use Chromium's low-end device mode.
@@ -3932,19 +3951,6 @@ Valid values:
  * +disable-all+: Disable all sandboxing (**not recommended!**).
 
 Default: +pass:[enable-all]+
-
-[[qt.chromium.use_recommended_page_lifecycle_state]]
-=== qt.chromium.use_recommended_page_lifecycle_state
-Use recommended page lifecycle state.
-This puts webpages into one of three lifecycle states: active, frozen, or discarded. Using the recommended lifecycle state lets the browser use less resources by freezing or discarding web views when it's safe to do so.
-This results in significant battery life savings.
-Ongoing page activity is taken into account when determining the recommended lifecycle state, as to not disrupt your browsing.
-
-This setting is only available with the QtWebEngine backend.
-
-Type: <<types,Bool>>
-
-Default: +pass:[false]+
 
 [[qt.environ]]
 === qt.environ

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1694,8 +1694,10 @@ class WebEngineTab(browsertab.AbstractTab):
             delay = config.val.qt.chromium.lifecycle_state_freeze_delay
         elif recommended_state == QWebEnginePage.LifecycleState.Discarded:
             delay = config.val.qt.chromium.lifecycle_state_discard_delay
-        else:
+        elif recommended_state == QWebEnginePage.LifecycleState.Active:
             delay = 0
+        else:
+            raise utils.Unreachable(recommended_state)
 
         try:
             self._lifecycle_timer.timeout.disconnect()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1305,6 +1305,8 @@ class WebEngineTab(browsertab.AbstractTab):
         self._child_event_filter = None
         self._saved_zoom = None
         self._scripts.init()
+        self._lifecycle_timer = usertypes.Timer(self)
+        self._lifecycle_timer.setSingleShot(True)
         # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
         self._needs_qtbug65223_workaround = (
             version.qtwebengine_versions().webengine < utils.VersionNumber(5, 15, 5))
@@ -1412,6 +1414,14 @@ class WebEngineTab(browsertab.AbstractTab):
         # renderer via IPC. This may increase its size. The maximum size of the
         # percent encoded content is 2 megabytes minus 30 bytes.
         self._widget.setHtml(html, base_url)
+
+    def _set_lifecycle_state(
+        self,
+        new_state: QWebEnginePage.LifecycleState,
+    ) -> None:
+        """Set the lifecycle state of the current tab."""
+        log.webview.debug(f"Setting page lifecycle state of {self} to {new_state}")
+        self._widget.page().setLifecycleState(new_state)
 
     def _show_error_page(self, url, error):
         """Show an error page in the tab."""
@@ -1668,6 +1678,30 @@ class WebEngineTab(browsertab.AbstractTab):
         else:
             selection.selectNone()
 
+    @pyqtSlot(QWebEnginePage.LifecycleState)
+    def _on_recommended_state_changed(
+            self,
+            recommended_state: QWebEnginePage.LifecycleState,
+    ) -> None:
+        disabled = not config.val.qt.chromium.use_recommended_page_lifecycle_state
+
+        # If the config is changed at runtime, stop freezing/discarding pages, but do
+        # recover pages that become active again.
+        if disabled and recommended_state != QWebEnginePage.LifecycleState.Active:
+            return
+
+        if recommended_state == QWebEnginePage.LifecycleState.Frozen:
+            delay = config.val.qt.chromium.lifecycle_state_freeze_delay
+        elif recommended_state == QWebEnginePage.LifecycleState.Discarded:
+            delay = config.val.qt.chromium.lifecycle_state_discard_delay
+        else:
+            delay = 0
+
+        self._lifecycle_timer.timeout.disconnect()
+        log.webview.debug(f"Setting lifecycle state {recommended_state} in {delay}ms")
+        self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
+        self._lifecycle_timer.start(delay)
+
     def _connect_signals(self):
         view = self._widget
         page = view.page()
@@ -1685,6 +1719,8 @@ class WebEngineTab(browsertab.AbstractTab):
         page.navigation_request.connect(self._on_navigation_request)
         page.printRequested.connect(self._on_print_requested)
         page.selectClientCertificate.connect(self._on_select_client_certificate)
+
+        page.recommendedStateChanged.connect(self._on_recommended_state_changed)
 
         view.titleChanged.connect(self.title_changed)
         view.urlChanged.connect(self._on_url_changed)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1305,8 +1305,14 @@ class WebEngineTab(browsertab.AbstractTab):
         self._child_event_filter = None
         self._saved_zoom = None
         self._scripts.init()
-        self._lifecycle_timer = usertypes.Timer(self)
-        self._lifecycle_timer.setSingleShot(True)
+
+        self._lifecycle_timer_freeze = usertypes.Timer(self)
+        self._lifecycle_timer_freeze.setSingleShot(True)
+        self._lifecycle_timer_freeze.timeout.connect(functools.partial(self._set_lifecycle_state, QWebEnginePage.LifecycleState.Frozen))
+        self._lifecycle_timer_discard = usertypes.Timer(self)
+        self._lifecycle_timer_discard.setSingleShot(True)
+        self._lifecycle_timer_discard.timeout.connect(functools.partial(self._set_lifecycle_state, QWebEnginePage.LifecycleState.Discarded))
+
         # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
         self._needs_qtbug65223_workaround = (
             version.qtwebengine_versions().webengine < utils.VersionNumber(5, 15, 5))
@@ -1678,44 +1684,61 @@ class WebEngineTab(browsertab.AbstractTab):
         else:
             selection.selectNone()
 
+    def _schedule_lifecycle_transition(
+        self,
+        state: Optional[QWebEnginePage.LifecycleState] = None,
+    ) -> None:
+        """Schedule, or cancel, a page lifecycle transition.
+
+        Schedule a lifecycle transition to `state`, according to the user's
+        config.
+        If a transition into `state` is already schedule, do nothing.
+        If `state` is `None`, cancel any scheduled transition.
+        """
+        timers = {
+            QWebEnginePage.LifecycleState.Frozen: (
+                self._lifecycle_timer_freeze,
+                config.val.qt.chromium.lifecycle_state_freeze_delay,
+            ),
+            QWebEnginePage.LifecycleState.Discarded: (
+                self._lifecycle_timer_discard,
+                config.val.qt.chromium.lifecycle_state_discard_delay,
+            ),
+        }
+
+        to_start = delay = None
+        if state is not None:
+            try:
+                to_start, delay = timers[state]
+            except KeyError:
+                raise utils.Unreachable(state)
+
+        for timer, _ in timers.values():
+            if timer != to_start:
+                timer.stop()
+
+        if to_start and not to_start.isActive() and delay != -1:
+            log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {state=} tab={self}")
+            to_start.start(delay)
+
     @pyqtSlot(QWebEnginePage.LifecycleState)
     def _on_recommended_state_changed(
             self,
             recommended_state: QWebEnginePage.LifecycleState,
     ) -> None:
+        if self._widget.page().lifecycleState() == recommended_state:
+            self._schedule_lifecycle_transition(None)
+            return
+
         disabled = not config.val.qt.chromium.use_recommended_page_lifecycle_state
 
-        # If the config is changed at runtime, stop freezing/discarding pages, but do
-        # recover pages that become active again.
-        if disabled and recommended_state != QWebEnginePage.LifecycleState.Active:
-            return
-
-        if recommended_state == QWebEnginePage.LifecycleState.Frozen:
-            delay = config.val.qt.chromium.lifecycle_state_freeze_delay
-        elif recommended_state == QWebEnginePage.LifecycleState.Discarded:
-            delay = config.val.qt.chromium.lifecycle_state_discard_delay
-        elif recommended_state == QWebEnginePage.LifecycleState.Active:
-            delay = 0
+        if recommended_state == QWebEnginePage.LifecycleState.Active:
+            self._schedule_lifecycle_transition(None)
+            self._set_lifecycle_state(recommended_state)
+        elif disabled or self.data.pinned:
+            self._schedule_lifecycle_transition(None)
         else:
-            raise utils.Unreachable(recommended_state)
-
-        try:
-            self._lifecycle_timer.timeout.disconnect()
-        except TypeError:
-            pass
-
-        if self._widget.page().lifecycleState() == recommended_state:
-            return
-
-        if delay < 0:
-            return
-
-        if self.data.pinned and recommended_state != QWebEnginePage.LifecycleState.Active:
-            return
-
-        log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {recommended_state=} tab={self}")
-        self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
-        self._lifecycle_timer.start(delay)
+            self._schedule_lifecycle_transition(recommended_state)
 
     def _connect_signals(self):
         view = self._widget

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1735,7 +1735,8 @@ class WebEngineTab(browsertab.AbstractTab):
         page.printRequested.connect(self._on_print_requested)
         page.selectClientCertificate.connect(self._on_select_client_certificate)
 
-        page.recommendedStateChanged.connect(self._on_recommended_state_changed)
+        if version.qtwebengine_versions().webengine >= utils.VersionNumber(6, 5):
+            page.recommendedStateChanged.connect(self._on_recommended_state_changed)
 
         view.titleChanged.connect(self.title_changed)
         view.urlChanged.connect(self._on_url_changed)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1705,6 +1705,9 @@ class WebEngineTab(browsertab.AbstractTab):
         if self._widget.page().lifecycleState() == recommended_state:
             return
 
+        if delay < 0:
+            return
+
         log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {recommended_state=} tab={self}")
         self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
         self._lifecycle_timer.start(delay)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1708,6 +1708,9 @@ class WebEngineTab(browsertab.AbstractTab):
         if delay < 0:
             return
 
+        if self.data.pinned and recommended_state != QWebEnginePage.LifecycleState.Active:
+            return
+
         log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {recommended_state=} tab={self}")
         self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
         self._lifecycle_timer.start(delay)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1697,8 +1697,15 @@ class WebEngineTab(browsertab.AbstractTab):
         else:
             delay = 0
 
-        self._lifecycle_timer.timeout.disconnect()
-        log.webview.debug(f"Setting lifecycle state {recommended_state} in {delay}ms")
+        try:
+            self._lifecycle_timer.timeout.disconnect()
+        except TypeError:
+            pass
+
+        if self._widget.page().lifecycleState() == recommended_state:
+            return
+
+        log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {recommended_state=} tab={self}")
         self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
         self._lifecycle_timer.start(delay)
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1695,14 +1695,15 @@ class WebEngineTab(browsertab.AbstractTab):
         If a transition into `state` is already schedule, do nothing.
         If `state` is `None`, cancel any scheduled transition.
         """
+        url = self.url() if self.url().isValid() else None
         timers = {
             QWebEnginePage.LifecycleState.Frozen: (
                 self._lifecycle_timer_freeze,
-                config.val.qt.chromium.lifecycle_state_freeze_delay,
+                config.instance.get('qt.chromium.lifecycle_state_freeze_delay', url=url),
             ),
             QWebEnginePage.LifecycleState.Discarded: (
                 self._lifecycle_timer_discard,
-                config.val.qt.chromium.lifecycle_state_discard_delay,
+                config.instance.get('qt.chromium.lifecycle_state_discard_delay', url=url),
             ),
         }
 
@@ -1730,7 +1731,8 @@ class WebEngineTab(browsertab.AbstractTab):
             self._schedule_lifecycle_transition(None)
             return
 
-        disabled = not config.val.qt.chromium.use_recommended_page_lifecycle_state
+        url = self.url() if self.url().isValid() else None
+        disabled = not config.instance.get('qt.chromium.use_recommended_page_lifecycle_state', url=url)
 
         if recommended_state == QWebEnginePage.LifecycleState.Active:
             self._schedule_lifecycle_transition(None)
@@ -1739,6 +1741,14 @@ class WebEngineTab(browsertab.AbstractTab):
             self._schedule_lifecycle_transition(None)
         else:
             self._schedule_lifecycle_transition(recommended_state)
+
+    @pyqtSlot(QUrl)
+    def _on_url_changed_recheck_lifecycle(self, url: QUrl) -> None:
+        if not url.isValid():
+            return
+
+        # Reset lifecycle delay config on URL change.
+        self._schedule_lifecycle_transition(None)
 
     def _connect_signals(self):
         view = self._widget
@@ -1760,6 +1770,7 @@ class WebEngineTab(browsertab.AbstractTab):
 
         if version.qtwebengine_versions().webengine >= utils.VersionNumber(6, 5):
             page.recommendedStateChanged.connect(self._on_recommended_state_changed)
+            view.urlChanged.connect(self._on_url_changed_recheck_lifecycle)
 
         view.titleChanged.connect(self.title_changed)
         view.urlChanged.connect(self._on_url_changed)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1699,11 +1699,11 @@ class WebEngineTab(browsertab.AbstractTab):
         timers = {
             QWebEnginePage.LifecycleState.Frozen: (
                 self._lifecycle_timer_freeze,
-                config.instance.get('qt.chromium.lifecycle_state_freeze_delay', url=url),
+                config.instance.get('content.lifecycle.freeze_ms', url=url),
             ),
             QWebEnginePage.LifecycleState.Discarded: (
                 self._lifecycle_timer_discard,
-                config.instance.get('qt.chromium.lifecycle_state_discard_delay', url=url),
+                config.instance.get('content.lifecycle.discard_ms', url=url),
             ),
         }
 
@@ -1732,7 +1732,7 @@ class WebEngineTab(browsertab.AbstractTab):
             return
 
         url = self.url() if self.url().isValid() else None
-        disabled = not config.instance.get('qt.chromium.use_recommended_page_lifecycle_state', url=url)
+        disabled = not config.instance.get('content.lifecycle.enabled', url=url)
 
         if recommended_state == QWebEnginePage.LifecycleState.Active:
             self._schedule_lifecycle_transition(None)

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -349,6 +349,7 @@ qt.chromium.use_recommended_page_lifecycle_state:
   type: Bool
   default: false
   backend: QtWebEngine
+  # yamllint disable rule:line-length
   desc: >-
     Use recommended page lifecycle state.
 
@@ -361,6 +362,9 @@ qt.chromium.use_recommended_page_lifecycle_state:
     Ongoing page activity is taken into account when determining the
     recommended lifecycle state, as to not disrupt your browsing.
 
+    See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
+  # yamllint enable rule:line-length
+
 qt.chromium.lifecycle_state_freeze_delay:
   type: Int
   default: 0
@@ -369,6 +373,8 @@ qt.chromium.lifecycle_state_freeze_delay:
     The amount of time (in milliseconds) to wait before transitioning a page to
     the frozen lifecycle state.
 
+    Set to -1 to disable this state (will also disable the discard state).
+
 qt.chromium.lifecycle_state_discard_delay:
   type: Int
   default: 0
@@ -376,6 +382,8 @@ qt.chromium.lifecycle_state_discard_delay:
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the discarded lifecycle state.
+
+    Set to -1 to disable this state.
 
 qt.highdpi:
   type: Bool

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -362,6 +362,9 @@ qt.chromium.use_recommended_page_lifecycle_state:
     Ongoing page activity is taken into account when determining the
     recommended lifecycle state, as to not disrupt your browsing.
 
+    This feature is only available on QtWebEngine 6.5+. On older versions
+    this setting is ignored.
+
     See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
   # yamllint enable rule:line-length
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -345,6 +345,38 @@ qt.chromium.experimental_web_platform_features:
     Chromium. By default, this is enabled with Qt 5 to maximize compatibility
     despite an aging Chromium base.
 
+qt.chromium.use_recommended_page_lifecycle_state:
+  type: Bool
+  default: false
+  backend: QtWebEngine
+  desc: >-
+    Use recommended page lifecycle state.
+
+    This puts webpages into one of three lifecycle states: active, frozen, or
+    discarded. Using the recommended lifecycle state lets the browser use less
+    resources by freezing or discarding web views when it's safe to do so.
+
+    This results in significant battery life savings.
+
+    Ongoing page activity is taken into account when determining the
+    recommended lifecycle state, as to not disrupt your browsing.
+
+qt.chromium.lifecycle_state_freeze_delay:
+  type: Int
+  default: 0
+  backend: QtWebEngine
+  desc: >-
+    The amount of time (in milliseconds) to wait before transitioning a page to
+    the frozen lifecycle state.
+
+qt.chromium.lifecycle_state_discard_delay:
+  type: Int
+  default: 0
+  backend: QtWebEngine
+  desc: >-
+    The amount of time (in milliseconds) to wait before transitioning a page to
+    the discarded lifecycle state.
+
 qt.highdpi:
   type: Bool
   default: false

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -369,17 +369,21 @@ qt.chromium.use_recommended_page_lifecycle_state:
   # yamllint enable rule:line-length
 
 qt.chromium.lifecycle_state_freeze_delay:
-  type: Int
+  type:
+    name: Int
+    minval: 0
+    maxval: maxint
   default: 0
   backend: QtWebEngine
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the frozen lifecycle state.
 
-    Set to -1 to disable this state (will also disable the discard state).
-
 qt.chromium.lifecycle_state_discard_delay:
-  type: Int
+  type:
+    name: Int
+    minval: -1
+    maxval: maxint
   default: 0
   backend: QtWebEngine
   desc: >-

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -350,6 +350,7 @@ qt.chromium.use_recommended_page_lifecycle_state:
   default: false
   backend: QtWebEngine
   # yamllint disable rule:line-length
+  supports_pattern: true
   desc: >-
     Use recommended page lifecycle state.
 
@@ -375,6 +376,7 @@ qt.chromium.lifecycle_state_freeze_delay:
     maxval: maxint
   default: 0
   backend: QtWebEngine
+  supports_pattern: true
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the frozen lifecycle state.
@@ -386,6 +388,7 @@ qt.chromium.lifecycle_state_discard_delay:
     maxval: maxint
   default: 0
   backend: QtWebEngine
+  supports_pattern: true
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the discarded lifecycle state.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -345,56 +345,6 @@ qt.chromium.experimental_web_platform_features:
     Chromium. By default, this is enabled with Qt 5 to maximize compatibility
     despite an aging Chromium base.
 
-qt.chromium.use_recommended_page_lifecycle_state:
-  type: Bool
-  default: false
-  backend: QtWebEngine
-  # yamllint disable rule:line-length
-  supports_pattern: true
-  desc: >-
-    Use recommended page lifecycle state.
-
-    This puts webpages into one of three lifecycle states: active, frozen, or
-    discarded. Using the recommended lifecycle state lets the browser use less
-    resources by freezing or discarding web views when it's safe to do so.
-
-    This results in significant battery life savings.
-
-    Ongoing page activity is taken into account when determining the
-    recommended lifecycle state, as to not disrupt your browsing.
-
-    This feature is only available on QtWebEngine 6.5+. On older versions
-    this setting is ignored.
-
-    See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
-  # yamllint enable rule:line-length
-
-qt.chromium.lifecycle_state_freeze_delay:
-  type:
-    name: Int
-    minval: 0
-    maxval: maxint
-  default: 0
-  backend: QtWebEngine
-  supports_pattern: true
-  desc: >-
-    The amount of time (in milliseconds) to wait before transitioning a page to
-    the frozen lifecycle state.
-
-qt.chromium.lifecycle_state_discard_delay:
-  type:
-    name: Int
-    minval: -1
-    maxval: maxint
-  default: 0
-  backend: QtWebEngine
-  supports_pattern: true
-  desc: >-
-    The amount of time (in milliseconds) to wait before transitioning a page to
-    the discarded lifecycle state.
-
-    Set to -1 to disable this state.
-
 qt.highdpi:
   type: Bool
   default: false
@@ -1127,6 +1077,56 @@ content.javascript.legacy_touch_events:
     Newer Chromium versions have those disabled by default:
     https://bugs.chromium.org/p/chromium/issues/detail?id=392584
     https://groups.google.com/a/chromium.org/g/blink-dev/c/KV6kqDJpYiE
+
+content.lifecycle.enabled:
+  type: Bool
+  default: false
+  backend: QtWebEngine
+  # yamllint disable rule:line-length
+  supports_pattern: true
+  desc: >-
+    Enable use of recommended page lifecycle state.
+
+    This puts webpages into one of three lifecycle states: active, frozen, or
+    discarded. Using the recommended lifecycle state lets the browser use less
+    resources by freezing or discarding web views when it's safe to do so.
+
+    This results in significant battery life savings.
+
+    Ongoing page activity is taken into account when determining the
+    recommended lifecycle state, as to not disrupt your browsing.
+
+    This feature is only available on QtWebEngine 6.5+. On older versions
+    this setting is ignored.
+
+    See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
+  # yamllint enable rule:line-length
+
+content.lifecycle.freeze_ms:
+  type:
+    name: Int
+    minval: 0
+    maxval: maxint
+  default: 0
+  backend: QtWebEngine
+  supports_pattern: true
+  desc: >-
+    The amount of time (in milliseconds) to wait before transitioning a page to
+    the frozen lifecycle state.
+
+content.lifecycle.discard_ms:
+  type:
+    name: Int
+    minval: -1
+    maxval: maxint
+  default: 0
+  backend: QtWebEngine
+  supports_pattern: true
+  desc: >-
+    The amount of time (in milliseconds) to wait before transitioning a page to
+    the discarded lifecycle state.
+
+    Set to -1 to disable this state.
 
 content.local_content_can_access_remote_urls:
   default: false

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1998,4 +1998,3 @@ Feature: Tab management
         And I run :tab-prev
         Then "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Frozen" should be logged
         And "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Discarded" should be logged
-        And I run :set qt.chromium.use_recommended_page_lifecycle_state false

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1990,6 +1990,7 @@ Feature: Tab management
         And I run :tab-prev
         Then "Entering mode KeyMode.insert (reason: mode_override)" should be logged
 
+    @qt>=6.5
     Scenario: Lifecycle change on tab switch
         When I set qt.chromium.use_recommended_page_lifecycle_state to true
         And I open about:blank?1

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1989,3 +1989,12 @@ Feature: Tab management
         And I open data/numbers/2.txt in a new tab
         And I run :tab-prev
         Then "Entering mode KeyMode.insert (reason: mode_override)" should be logged
+
+    Scenario: Lifecycle change on tab switch
+        When I set qt.chromium.use_recommended_page_lifecycle_state to true
+        And I open about:blank?1
+        And I open about:blank?2 in a new tab
+        And I run :tab-prev
+        Then "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Frozen" should be logged
+        And "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Discarded" should be logged
+        And I run :set qt.chromium.use_recommended_page_lifecycle_state false

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1992,7 +1992,7 @@ Feature: Tab management
 
     @qt>=6.5
     Scenario: Lifecycle change on tab switch
-        When I set qt.chromium.use_recommended_page_lifecycle_state to true
+        When I set content.lifecycle.enabled to true
         And I open about:blank?1
         And I open about:blank?2 in a new tab
         And I run :tab-prev

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -352,9 +352,9 @@ class TestPageLifecycle:
         """For negative delay values, the timer shouldn't be scheduled."""
         self.set_config(
             config_stub,
-            freeze_delay=-1,
+            discard_delay=-1,
         )
-        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
+        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Discarded)
         assert not webengine_tab._lifecycle_timer.isActive()
 
     def test_pinned_tabs_untouched(

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -333,6 +333,20 @@ class TestPageLifecycle:
             pass
         set_state_spy.assert_called_once_with(new_state)
 
+    def test_state_disabled(
+        self,
+        webengine_tab: webenginetab.WebEngineTab,
+        monkeypatch,
+        config_stub,
+    ):
+        """For negative delay values, the timer shouldn't be scheduled."""
+        self.set_config(
+            config_stub,
+            freeze_delay=-1,
+        )
+        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
+        assert not webengine_tab._lifecycle_timer.isActive()
+
     def test_timer_interrupted(
         self,
         webengine_tab: webenginetab.WebEngineTab,

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -14,11 +14,13 @@ QWebEngineScriptCollection = QtWebEngineCore.QWebEngineScriptCollection
 QWebEngineScript = QtWebEngineCore.QWebEngineScript
 
 from qutebrowser.browser import greasemonkey
-from qutebrowser.utils import usertypes
+from qutebrowser.utils import usertypes, utils, version
 webenginetab = pytest.importorskip(
     "qutebrowser.browser.webengine.webenginetab")
 
 pytestmark = pytest.mark.usefixtures('greasemonkey_manager')
+
+versions = version.qtwebengine_versions(avoid_init=True)
 
 
 class ScriptsHelper:
@@ -247,6 +249,14 @@ class TestWebEnginePermissions:
 
 
 class TestPageLifecycle:
+
+    @pytest.fixture(autouse=True)
+    def check_version(self):
+        # While the lifecycle feature was introduced in 5.14, PyQt seems to
+        # have trouble connecting to the signal we require on 6.4 and prior.
+        # https://github.com/qutebrowser/qutebrowser/pull/8547#issuecomment-2890997662
+        if versions.webengine < utils.VersionNumber(6, 5):
+            pytest.skip("Lifecycle feature requires Webengine 6.5+")
 
     @pytest.fixture
     def set_state_spy(

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -347,6 +347,17 @@ class TestPageLifecycle:
         webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
         assert not webengine_tab._lifecycle_timer.isActive()
 
+    def test_pinned_tabs_untouched(
+        self,
+        webengine_tab: webenginetab.WebEngineTab,
+        monkeypatch,
+        config_stub,
+    ):
+        """Don't change lifecycle state for a pinned tab."""
+        webengine_tab.set_pinned(True)
+        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
+        assert not webengine_tab._lifecycle_timer.isActive()
+
     def test_timer_interrupted(
         self,
         webengine_tab: webenginetab.WebEngineTab,

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -259,25 +259,25 @@ class TestPageLifecycle:
             pytest.skip("Lifecycle feature requires Webengine 6.5+")
 
     @pytest.fixture
-    def set_state_spy(
+    def set_state_mock(
         self,
         webengine_tab: webenginetab.WebEngineTab,
         monkeypatch,
         mocker,
     ):
-        set_state_spy = mocker.Mock()
+        set_state_mock = mocker.Mock()
         monkeypatch.setattr(
             webengine_tab._widget.page(),
             "setLifecycleState",
-            set_state_spy,
+            set_state_mock,
         )
-        return set_state_spy
+        return set_state_mock
 
     @pytest.fixture(autouse=True)
     def set_config_defaults(
         self,
         config_stub,
-        set_state_spy,
+        set_state_mock,
     ):
         self.set_config(config_stub)
 
@@ -295,14 +295,14 @@ class TestPageLifecycle:
     def test_qt_method_is_called(
         self,
         webengine_tab: webenginetab.WebEngineTab,
-        set_state_spy,
+        set_state_mock,
         qtbot,
     ):
         """Basic test to show that we call QT after going through our code."""
         webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Discarded)
         with qtbot.wait_signal(webengine_tab._lifecycle_timer.timeout):
             pass
-        set_state_spy.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)
+        set_state_mock.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)
 
     @pytest.mark.parametrize(
         "new_state, freeze_delay, discard_delay",
@@ -316,7 +316,7 @@ class TestPageLifecycle:
         webengine_tab: webenginetab.WebEngineTab,
         monkeypatch,
         mocker,
-        set_state_spy,
+        set_state_mock,
         config_stub,
         qtbot,
         new_state,
@@ -341,7 +341,7 @@ class TestPageLifecycle:
 
         with qtbot.wait_signal(timer.timeout, timeout=100):
             pass
-        set_state_spy.assert_called_once_with(new_state)
+        set_state_mock.assert_called_once_with(new_state)
 
     def test_state_disabled(
         self,
@@ -371,7 +371,7 @@ class TestPageLifecycle:
     def test_timer_interrupted(
         self,
         webengine_tab: webenginetab.WebEngineTab,
-        set_state_spy,
+        set_state_mock,
         config_stub,
         qtbot,
     ):
@@ -390,4 +390,4 @@ class TestPageLifecycle:
 
         with qtbot.wait_signal(webengine_tab._lifecycle_timer.timeout):
             pass
-        set_state_spy.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)
+        set_state_mock.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -288,9 +288,9 @@ class TestPageLifecycle:
         discard_delay=0,
         enabled=True,
     ):
-        config_stub.val.qt.chromium.lifecycle_state_freeze_delay = freeze_delay
-        config_stub.val.qt.chromium.lifecycle_state_discard_delay = discard_delay
-        config_stub.val.qt.chromium.use_recommended_page_lifecycle_state = enabled
+        config_stub.instance.content.lifecycle.freeze_ms = freeze_delay
+        config_stub.instance.content.lifecycle.discard_ms = discard_delay
+        config_stub.instance.content.lifecycle.enabled = enabled
 
     def timer_for(self, tab, state):  # pylint: disable=inconsistent-return-statements
         if state == QWebEnginePage.LifecycleState.Frozen:


### PR DESCRIPTION
Some sites (like gmail, chatgpt) can be slow to reload, others like chats (slack, element.io etc) shouldn't even be frozen to keep notifications working.

Thi sPR adds support to set lifecycle options with --pattern, for example:
Don't discard gmail:
```
set --pattern https://mail.google.com/* qt.chromium.lifecycle_state_discard_delay -1
```
Don't discard or freeze slack:
```
set --pattern https://app.slack.com/* qt.chromium.lifecycle_state_freeze_delay -1
set --pattern https://app.slack.com/* qt.chromium.lifecycle_state_discard_delay -1
```
Disable lifecycle config for a site:
```
set --pattern https://app.element.io/* qt.chromium.use_recommended_page_lifecycle_state false
```

Default to freeze and discard everything else after 1/10 minutes:
```
set qt.chromium.use_recommended_page_lifecycle_state true
set qt.chromium.lifecycle_state_discard_delay 600000
set qt.chromium.lifecycle_state_freeze_delay 60000
```

I've only tested it for a couple hours but it seems to work as intended. :)

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
